### PR TITLE
Fixed issue with shifted CPU metrics

### DIFF
--- a/bin/metrics-iostat-extended.rb
+++ b/bin/metrics-iostat-extended.rb
@@ -88,6 +88,7 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
       fields = line.split(/\s+/)
 
       key = fields.shift if stage == :device
+      fields.shift if stage == :cpu
       stats[key] = Hash[headers.zip(fields.map(&:to_f))]
     end
     stats


### PR DESCRIPTION
The split on fields ends up with a padded empty string when `stage = :cpu`. To avoid getting the wrong metrics (see below), I'm shifting the fields before we create the hash.

Here is an example output from `iostat -x 5 2`:

```
me@myhost:~$ iostat -x 5 2
Linux 3.13.0-53-generic (myhost)    10/14/2015  _x86_64_    (4 CPU)

avg-cpu:  %user   %nice %system %iowait  %steal   %idle
          28.21    0.00   19.59    0.04   12.46   39.70

Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
sda               0.04     9.82    0.06    3.69     0.82    59.16    32.04     0.06   15.32    4.38   15.49   1.40   0.52

avg-cpu:  %user   %nice %system %iowait  %steal   %idle
          14.95    0.00   24.33    0.10   14.95   45.67

Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
sda               0.00    12.18    0.00   10.98
```

Before (note the initial 0.0 and every metric is shifted one):

```
myhost.iostat.avg-cpu.pct_user 0.0 1444847382
myhost.iostat.avg-cpu.pct_nice 13.12 1444847382
myhost.iostat.avg-cpu.pct_system 0.0 1444847382
myhost.iostat.avg-cpu.pct_iowait 20.9 1444847382
myhost.iostat.avg-cpu.pct_steal 0.0 1444847382
myhost.iostat.avg-cpu.pct_idle 14.09 1444847382
```

After (note the shift, and now we have valid stats)

```
myhost.iostat.avg-cpu.pct_user 13.67 1444847459
myhost.iostat.avg-cpu.pct_nice 0.0 1444847459
myhost.iostat.avg-cpu.pct_system 23.62 1444847459
myhost.iostat.avg-cpu.pct_iowait 0.0 1444847459
myhost.iostat.avg-cpu.pct_steal 14.51 1444847459
myhost.iostat.avg-cpu.pct_idle 48.2 1444847459
```
