### PR TITLE
fix locale bug, adding rspec test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased][unreleased]
+## [Unreleased][unreleased]
+### Added
+- rspec test cases for metrics-iostat-extended
+- add proper device node handling for exclude-disk filtering
+
+### Fixed
+- fix an ordering issue on exclude-disk filtering
+- fix locale bug when calling iostat on non en_us systems
+
+### Changed
+- use open3 instead of backticks for proper call to iostat
+- filter exclude-disk in ruby code instead of shell grepping
+- do not pass any environment vars from sensu to iostat call
 
 ## [0.0.3] - 2015-10-15
 ### Changed

--- a/bin/metrics-iostat-extended.rb
+++ b/bin/metrics-iostat-extended.rb
@@ -110,7 +110,7 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
     stdin, stdout, stderr = Open3.popen3(cmd, *args, unsetenv_others: true)
     stdin.close
     stderr.close
-    stats = parse_results(stdout.gets(nil, nil))
+    stats = parse_results(stdout.gets(nil))
     stdout.close
 
     timestamp = Time.now.to_i

--- a/bin/metrics-iostat-extended.rb
+++ b/bin/metrics-iostat-extended.rb
@@ -29,6 +29,7 @@
 #
 
 require 'sensu-plugin/metric/cli'
+require 'open3'
 require 'socket'
 
 class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
@@ -95,20 +96,27 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
-    cmd = "iostat -x #{config[:interval]} 2"
+    cmd = 'iostat'
+    args = ['-x', config[:interval].to_s, '2']
+    args.push('-N') if config[:mappernames]
+    args.push(File.basename(config[:disk])) if config[:disk]
 
-    cmd += " #{File.basename(config[:disk])}" if config[:disk]
     if config[:excludedisk]
-      config[:excludedisk].each do |disk|
-        cmd += " | grep -v #{disk}"
-      end
+      exclude_disk = config[:excludedisk].map { |d| File.basename(d) }
+    else
+      exclude_disk = []
     end
-    cmd += ' -N' if config[:mappernames]
-    stats = parse_results(`#{cmd}`)
+
+    stdin, stdout, stderr = Open3.popen3(cmd, *args, unsetenv_others: true)
+    stdin.close
+    stderr.close
+    stats = parse_results(stdout.gets(nil, nil))
+    stdout.close
 
     timestamp = Time.now.to_i
 
     stats.each do |disk, metrics|
+      next if exclude_disk.include? disk
       metrics.each do |metric, value|
         output [config[:scheme], disk, metric].join('.'), value, timestamp
       end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,0 +1,16 @@
+def iostat_result
+  iostat =
+<<-EOF
+Linux 3.16.0-4-amd64 (foobar)       01/15/16        _x86_64_        (4 CPU)
+
+avg-cpu:  %user   %nice %system %iowait  %steal   %idle
+           2.91    0.00    0.51    0.91    0.00   95.68
+
+Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
+sda               3.22     0.40    7.02    3.91   105.66   117.36    40.81     0.18   16.02    6.11   33.82   2.71   2.96
+md0               0.00     0.00   38.65    9.09   298.09    97.37    16.57     0.00    0.00    0.00    0.00   0.00   0.00
+
+EOF
+
+  [StringIO.new('stdin'), StringIO.new(iostat), StringIO.new('stderr')]
+end

--- a/test/metrics-iostat_spec.rb
+++ b/test/metrics-iostat_spec.rb
@@ -1,0 +1,104 @@
+require_relative './plugin_stub.rb'
+require_relative './fixtures.rb'
+require_relative './spec_helper.rb'
+require_relative '../bin/metrics-iostat-extended.rb'
+
+describe IOStatExtended, 'syscall' do
+  it 'should call iostat' do
+    io = IOStatExtended.new
+    expect(Open3).to begin
+      receive(:popen3)
+        .with('iostat', '-x', '1', '2', unsetenv_others: true)
+        .and_return iostat_result
+    end
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should handle interval option' do
+    io = IOStatExtended.new
+    io.config[:interval] = 4
+    expect(Open3).to begin
+      receive(:popen3)
+        .with('iostat', '-x', '4', '2', unsetenv_others: true)
+        .and_return iostat_result
+    end
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should call iostat -N if mappernames option set' do
+    io = IOStatExtended.new
+    io.config[:mappernames] = true
+    expect(Open3).to begin
+      receive(:popen3)
+        .with('iostat', '-x', '1', '2', '-N', unsetenv_others: true)
+        .and_return iostat_result
+    end
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should call iostat -d for given disk if disk option set' do
+    io = IOStatExtended.new
+    io.config[:disk] = '/dev/sda'
+    expect(Open3).to begin
+      receive(:popen3)
+        .with('iostat', '-x', '1', '2', 'sda', unsetenv_others: true)
+        .and_return iostat_result
+    end
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should handle exclude-disk and mappernames ordering' do
+    io = IOStatExtended.new
+    io.config[:excludedisk] = %w(sda)
+    io.config[:mappernames] = true
+    expect(Open3).to begin
+      receive(:popen3)
+        .with('iostat', '-x', '1', '2', '-N', unsetenv_others: true)
+        .and_return iostat_result
+    end
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+end
+
+describe IOStatExtended, 'output' do
+  before(:example) do
+    expect(Open3).to receive(:popen3).and_return iostat_result
+  end
+
+  it 'should print metrics' do
+    io = IOStatExtended.new
+    expect(io).to receive(:output).with(no_args)
+    expect(io).to receive(:output).with(kind_of(String), kind_of(Numeric), kind_of(Numeric)).exactly(32).times
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should handle scheme' do
+    io = IOStatExtended.new
+    io.config[:scheme] = 'foo.bar'
+    expect(io).to receive(:output).with(no_args)
+    expect(io).to receive(:output).with(/^foo\.bar/, kind_of(Numeric), kind_of(Numeric)).exactly(32).times
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should exclude given disk if excludedisk option set' do
+    io = IOStatExtended.new
+    io.config[:excludedisk] = ['sda']
+    expect(io).to_not receive(:output).with(/^.*sda\.\w*$/, anything, anything)
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should handle multiple disk for excludedisk' do
+    io = IOStatExtended.new
+    io.config[:excludedisk] = %w(sda md0)
+    expect(io).to_not receive(:output).with(/^.*sda\.\w*$/, anything, anything)
+    expect(io).to_not receive(:output).with(/^.*md0\.\w*$/, anything, anything)
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+
+  it 'should handle full dev node path for excludedisk' do
+    io = IOStatExtended.new
+    io.config[:excludedisk] = %w(/dev/sda)
+    expect(io).to_not receive(:output).with(/^.*sda\.\w*$/, anything, anything)
+    expect(-> { io.run }).to raise_error SystemExit
+  end
+end

--- a/test/plugin_stub.rb
+++ b/test/plugin_stub.rb
@@ -1,0 +1,24 @@
+RSpec.configure do |c|
+  c.before { allow($stdout).to receive(:puts) }
+  c.before { allow($stderr).to receive(:puts) }
+
+  # XXX: Sensu plugins run in the context of an at_exit handler. This prevents
+  # XXX: code-under-test from being run at the end of the rspec suite.
+  c.before(:each) do
+    Sensu::Plugin::CLI.class_eval do
+      # PluginStub
+      class PluginStub
+        def run; end
+
+        def ok(*); end
+
+        def warning(*); end
+
+        def critical(*); end
+
+        def unknown(*); end
+      end
+      class_variable_set(:@@autorun, PluginStub)
+    end
+  end
+end


### PR DESCRIPTION
This pull request is mainly dedicated to fix a locale issue in metrics-iostat-extended. When calling iostat, several values may contain ',' instead of '.' for floating point values on non en-us systems, resulting in wrong measurements when casting to ruby floats afterwards.

This pull request also fixes an ordering bug. If there are disks to exclude, there are already pipes to grep added to the constructed shell call, when there are still parameters left to be added to iostat:

```
./bin/metrics-iostat-extended.rb -x sda -N
grep: invalid option -- 'N'
```

Furthermore, there are several minor code improvements for a cleaner iostat handling. See Changelog for details.

To not break anything, I started to add rspec tests for the legacy code. I made my changes followed up by the test cases. So as a  benefit, there are some rspec tests for metrics-iostat-extended.
