### PR TITLE
Remove Ruby 1.9.3 support; add Ruby 2.3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:
@@ -26,8 +26,8 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
     repo: sensu-plugins/sensu-plugins-io-checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - use open3 instead of backticks for proper call to iostat
 - filter exclude-disk in ruby code instead of shell grepping
 - do not pass any environment vars from sensu to iostat call
+- Update to Rubocop 0.40, apply auto-correct
+- Remove Ruby 1.9.3 support; add Ruby 2.3.0 support to test matrix
 
 ## [0.0.3] - 2015-10-15
 ### Changed

--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,7 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
+args = [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
 
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze

--- a/sensu-plugins-io-checks.gemspec
+++ b/sensu-plugins-io-checks.gemspec
@@ -2,14 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-io-checks'
-else
-  require_relative 'lib/sensu-plugins-io-checks'
-end
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
+require_relative 'lib/sensu-plugins-io-checks'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
@@ -32,7 +25,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for io checks'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

This PR removes Ruby 1.9.3 support, and adds support for testing under Ruby 2.3.0, per the Sensu Plugins policy: 

> Ruby 1.9.3 (EOL): Linting is not done against it, and 1.9.3 will be supported where possible till Feb 2016 which is one year after EOL and 2 years after EOL was announced.
#### Known Compatibility Issues

Adds incompatibility with Ruby version < 2.0.0
