### PR TITLE
ioping nanosecond precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+- [ioping]https://github.com/koct9i/ioping is switching to nanosecond precision - added 'ns' to metrics-ioping.rb
+
 ## [1.0.0] - 2016-06-20
 ### Added
 - rspec test cases for metrics-iostat-extended

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 
 ### Fixed
-- [ioping]https://github.com/koct9i/ioping is switching to nanosecond precision - added 'ns' to metrics-ioping.rb
+- [ioping](https://github.com/koct9i/ioping) is switching to nanosecond precision - added 'ns' to metrics-ioping.rb
 
 ## [1.0.0] - 2016-06-20
 ### Added

--- a/bin/metrics-ioping.rb
+++ b/bin/metrics-ioping.rb
@@ -97,8 +97,9 @@ class IOPingMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   NUMBER = /\d+(?:\.\d+)?/
-  TIME_UNIT = /(?:us|ms|s|min|hour|day)/
+  TIME_UNIT = /(?:ns|us|ms|s|min|hour|day)/
   TIME_UNITS = {
+    'ns' => 1e-9,
     'us' => 1e-6,
     'ms' => 1e-3,
     's' => 1,


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No.  
#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

#### Purpose

Started seeing ioping check failures in Sensu and discovered it was because ioping on CentOS 6.5 (possibly other OS as well) is now returning results in nanoseconds.

```
--- /dev/sdb (block device 750 GiB) ioping statistics ---
0 requests completed in 0 ns, 0 B read, 0 iops, 0 B/s
generated 1 requests in 14.5 ms, 4 KiB, 68 iops, 275.6 KiB/s
min/avg/max/mdev = 0 ns / 0 ns / 0 ns / 0 ns
```

#### Known Compatibility Issues

The addition of 'ns' has no impact on systems not returning ioping results in 'ns' yet.
