### PR TITLE
Dmichelotto patch 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Added
 - ruby 2.4 testing (@majormoses)
+### Fixed
+- [iostat] Changes ouput in device session from 'Device:' to 'Device'. Fix issue  #12 (@dmichelotto)
 
 ## [1.0.1] - 2017-0702
 ### Fixed

--- a/bin/metrics-iostat-extended.rb
+++ b/bin/metrics-iostat-extended.rb
@@ -85,7 +85,7 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
         headers = line.gsub(/%/, 'pct_').split(/\s+/)
         headers.shift
         next
-      when /^(Device):/
+      when /^(Device).*/
         stage = :device
         headers = line.gsub(/%/, 'pct_').split(/\s+/).map { |h| h.gsub(/\//, '_per_') }
         headers.shift

--- a/bin/metrics-iostat-extended.rb
+++ b/bin/metrics-iostat-extended.rb
@@ -85,7 +85,7 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
         headers = line.gsub(/%/, 'pct_').split(/\s+/)
         headers.shift
         next
-      when /^(Device).*/
+      when /^(Device):\s+.+/, /^(Device)\s+.+/
         stage = :device
         headers = line.gsub(/%/, 'pct_').split(/\s+/).map { |h| h.gsub(/\//, '_per_') }
         headers.shift


### PR DESCRIPTION
## Pull Request Checklist

Fix #12 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Fix wrong parsing for iostat output after package upgrade > 10

Before:
```bash
/opt/sensu/embedded/bin/metrics-iostat-extended.rb --scheme test
test.avg-cpu.pct_user 8.5 1540197146
test.avg-cpu.pct_nice 0.0 1540197146
test.avg-cpu.pct_system 2.25 1540197146
test.avg-cpu.pct_iowait 0.0 1540197146
test.avg-cpu.pct_steal 0.0 1540197146
test.avg-cpu.pct_idle 89.25 1540197146
```

After:
```bash
/opt/sensu/embedded/bin/metrics-iostat-extended.rb --scheme test
test.avg-cpu.pct_user 8.5 1540197146
test.avg-cpu.pct_nice 0.0 1540197146
test.avg-cpu.pct_system 2.25 1540197146
test.avg-cpu.pct_iowait 0.0 1540197146
test.avg-cpu.pct_steal 0.0 1540197146
test.avg-cpu.pct_idle 89.25 1540197146
test.sda.r_per_s 0.0 1540197146
test.sda.w_per_s 0.0 1540197146
test.sda.rkB_per_s 0.0 1540197146
test.sda.wkB_per_s 0.0 1540197146
test.sda.rrqm_per_s 0.0 1540197146
test.sda.wrqm_per_s 0.0 1540197146
test.sda.pct_rrqm 0.0 1540197146
test.sda.pct_wrqm 0.0 1540197146
test.sda.r_await 0.0 1540197146
test.sda.w_await 0.0 1540197146
test.sda.aqu-sz 0.0 1540197146
test.sda.rareq-sz 0.0 1540197146
test.sda.wareq-sz 0.0 1540197146
test.sda.svctm 0.0 1540197146
test.sda.pct_util 0.0 1540197146
```

#### Known Compatibility Issues
